### PR TITLE
Nrel refactor

### DIFF
--- a/app/controllers/ev_map_controller.rb
+++ b/app/controllers/ev_map_controller.rb
@@ -6,7 +6,7 @@ class EvMapController < ApplicationController
     @ev_search_lat = session[:ev_search]["latitude"]
     @ev_search_lon = session[:ev_search]["longitude"]
     @ev_facade = EvStationFacade.new(@ev_search_lat, @ev_search_lon)
-    @ev_stations = @ev_facade.public_ev_stations
+    @ev_stations = @ev_facade.ev_stations
     @picked_location = {
       latitude: @ev_search_lat,
       longitude: @ev_search_lon,

--- a/app/facades/ev_station_facade.rb
+++ b/app/facades/ev_station_facade.rb
@@ -4,15 +4,9 @@ class EvStationFacade
     @lon = lon
   end
 
-  def all_ev_stations
+  def ev_stations
     service.raw_ev_charging_stations.map do |ev_info|
       EvStation.new(ev_info)
-    end
-  end
-
-  def public_ev_stations
-    all_ev_stations.select do |station|
-      station.availibility == "Public"
     end
   end
 

--- a/app/services/nrel_service.rb
+++ b/app/services/nrel_service.rb
@@ -14,7 +14,8 @@ class NrelService
       faraday.params["api_key"] = ENV['NREL_API_KEY']
       faraday.params["fuel_type"] = "ELEC"
       faraday.params["limit"] = 20
-      faraday.params["range"] = 2
+      faraday.params["range"] = 1
+      faraday.params["access"] = "public"
       faraday.params["latitude"] = @lat
       faraday.params["longitude"] = @lon
       faraday.adapter Faraday.default_adapter

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,7 +17,6 @@ ActiveRecord::Schema.define(version: 2019_02_20_023736) do
 
   create_table "destinations", force: :cascade do |t|
     t.string "name"
-    t.string "url"
     t.string "location"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/spec/facades/ev_station_facade_spec.rb
+++ b/spec/facades/ev_station_facade_spec.rb
@@ -8,20 +8,12 @@ describe EvStationFacade do
 
     expect(evsf).to be_a(EvStationFacade)
   end
-  it 'all_ev_stations', :vcr do
+  it 'ev_stations', :vcr do
     lat = "39.7392"
     lon = "-104.9903"
     evsf = EvStationFacade.new(lat, lon)
 
-    expect(evsf.all_ev_stations.count).to eq(20)
-    expect(evsf.all_ev_stations.first).to be_a(EvStation)
-  end
-  it 'public_ev_stations', :vcr do
-    lat = "39.7392"
-    lon = "-104.9903"
-    evsf = EvStationFacade.new(lat, lon)
-
-    # expect(evsf.public_ev_stations.count).to eq(15) this test keeps fluctuating from 14 to 15 
-    expect(evsf.public_ev_stations.first).to be_a(EvStation)
+    expect(evsf.ev_stations.count).to eq(20)
+    expect(evsf.ev_stations.first).to be_a(EvStation)
   end
 end


### PR DESCRIPTION
Refactored NRel service to only return public stations, this included refactoring the ev station facade and changing syntax in the ev map controller. all tests currently passing, this is working locally in production as well as in in development. this fixes the test that was unreliable.